### PR TITLE
Adapt ckan-ogc to ckanext-scheming_dcat multilang version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ DEFAULT_LICENSE_ID=cc-by
 PARALLELIZATION=False
 ## CKAN Dataset schema (geodcatap_es, geodcatap_eu)
 CKAN_DATASET_SCHEMA=geodcatap_eu
+## CKAN Dataset multilang if use ckanext-scheming_dcat improvement or ckanext-fluent to translated fields (True/False)
+CKAN_DATASET_MULTILANG=False
 ## ckan-ogc unverified mode (True/False).  SSL certificate from host will download if SSL_UNVERIFIED_MODE=True, to avoid SSL error when certificate was self-signed.
 SSL_UNVERIFIED_MODE=False
 ## If desired to export metadata records (GeoDCAT-AP/ISO19139) as a distributions of the CKAN dataset, set METADATA_DISTRIBUTIONS=True

--- a/ckan-ogc/Dockerfile
+++ b/ckan-ogc/Dockerfile
@@ -7,6 +7,7 @@ RUN echo ${TZ} > /etc/timezone
 ENV CKAN_URL=http://localhost:5000/
 ENV PYCSW_URL=http://localhost:8000/
 ENV CKAN_API_KEY=ckan-api-key
+ENV CKAN_DATASET_MULTILANG=False
 ENV DEFAULT_LICENSE=http://creativecommons.org/licenses/by/4.0/
 ENV DEFAULT_LICENSE_ID=cc-by
 ENV DEV_MODE=False

--- a/ckan-ogc/Dockerfile.dev
+++ b/ckan-ogc/Dockerfile.dev
@@ -7,6 +7,7 @@ RUN echo ${TZ} > /etc/timezone
 ENV CKAN_URL=http://localhost:5000/
 ENV PYCSW_URL=http://localhost:8000/
 ENV CKAN_API_KEY=ckan-api-key
+ENV CKAN_DATASET_MULTILANG=False
 ENV DEFAULT_LICENSE=http://creativecommons.org/licenses/by/4.0/
 ENV DEFAULT_LICENSE_ID=cc-by
 ENV DEV_MODE=True
@@ -29,8 +30,9 @@ RUN pdm install --no-self --group prod
 COPY ckan-ogc/conf/config.yaml.template config.yaml
 COPY ckan-ogc/docker-entrypoint.d/entrypoint_dev.sh entrypoint.sh
 
-EXPOSE 5678/TCP
+EXPOSE ${CKAN_OGC_DEV_PORT}/TCP
 
 # Set entrypoint with debugpy
-ENTRYPOINT ["python3", "-m", "debugpy", "--listen", "0.0.0.0:${PYCSW_DEV_PORT}", "--wait-for-client", "./entrypoint_dev.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "python3 -m debugpy --listen 0.0.0.0:${CKAN_OGC_DEV_PORT} --wait-for-client ./entrypoint_dev.sh"]
+
 CMD ["tail", "-f", "/dev/null"]

--- a/ckan-ogc/Dockerfile.ghcr
+++ b/ckan-ogc/Dockerfile.ghcr
@@ -7,6 +7,7 @@ RUN echo ${TZ} > /etc/timezone
 ENV CKAN_URL=http://localhost:5000/
 ENV PYCSW_URL=http://localhost:8000/
 ENV CKAN_API_KEY=ckan-api-key
+ENV CKAN_DATASET_MULTILANG=False
 ENV DEFAULT_LICENSE=http://creativecommons.org/licenses/by/4.0/
 ENV DEFAULT_LICENSE_ID=cc-by
 ENV DEV_MODE=False

--- a/ckan-ogc/Dockerfile.ghcr.dev
+++ b/ckan-ogc/Dockerfile.ghcr.dev
@@ -7,6 +7,7 @@ RUN echo ${TZ} > /etc/timezone
 ENV CKAN_URL=http://localhost:5000/
 ENV PYCSW_URL=http://localhost:8000/
 ENV CKAN_API_KEY=ckan-api-key
+ENV CKAN_DATASET_MULTILANG=False
 ENV DEFAULT_LICENSE=http://creativecommons.org/licenses/by/4.0/
 ENV DEFAULT_LICENSE_ID=cc-by
 ENV DEV_MODE=False
@@ -19,8 +20,9 @@ WORKDIR ${APP_DIR}
 COPY ckan-ogc/conf/config.yaml.template config.yaml
 COPY ckan-ogc/docker-entrypoint.d/entrypoint_dev.sh entrypoint.sh
 
-EXPOSE 5678/TCP
+EXPOSE ${CKAN_OGC_DEV_PORT}/TCP
 
 # Set entrypoint with debugpy
-ENTRYPOINT ["python3", "-m", "debugpy", "--listen", "0.0.0.0:${PYCSW_DEV_PORT}", "--wait-for-client", "./entrypoint_dev.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "python3 -m debugpy --listen 0.0.0.0:${CKAN_OGC_DEV_PORT} --wait-for-client ./entrypoint_dev.sh"]
+
 CMD ["tail", "-f", "/dev/null"]

--- a/ckan-ogc/conf/config.yaml.template
+++ b/ckan-ogc/conf/config.yaml.template
@@ -27,6 +27,7 @@ harvest_servers:
       topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/farming'
       lineage_process_steps: 'Spatial dataset generated from the original cartography provided by the competent national agency.'
       topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment'
+      theme: 'http://inspire.ec.europa.eu/theme/tn'
       theme_es: 'http://datos.gob.es/kos/sector-publico/sector/transporte'
       theme_eu: http://publications.europa.eu/resource/authority/data-theme/ENVI
       spatial: '{"coordinates": [[[-32.17,26.79],[44.49,26.79],[44.49,71.30],[-32.17,71.30],[-32.17,26.79]]], "type": "Polygon"}'
@@ -39,7 +40,7 @@ harvest_servers:
       - name: "environment"
         uri: "http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment"
     default_inspire_info:
-      inspireid_theme: 'HB'
+      inspireid_theme: 'TN'
       inspireid_nutscode: 'ES' 
       inspireid_versionid: '2023'
     constraints: 
@@ -59,30 +60,34 @@ harvest_servers:
     custom_organization_mapping_file: ''
     private_datasets: True
     default_dcat_info:
-      publisher_name: 'Example Organization'
+      publisher_name: 'Example project'
       publisher_email: 'info@example.eu'
       publisher_identifier: 'https://www.example.eu/org/E05068001'
       publisher_url: 'https://www.example.eu'
       publisher_type: 'http://purl.org/adms/publishertype/NationalAuthority'
       # Default URIs of metadata contact point and resource maintainer
-      maintainer_uri: 'https://www.example.eu/org/E05068001'
-      contact_name: 'Example Organization'
-      contact_email: 'info@example.eu'
-      contact_uri: 'https://www.example.eu/org/E05068001'
-      contact_url: 'https://www.example.eu'
+      maintainer_uri: 'https://example.eu/'
+      contact_uri: 'https://example.eu/'
+      contact_name: 'Example'
+      contact_email: 'info@example.es'
+      contact_url: 'https://example.eu/'
+      topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/farming'
+      lineage_process_steps: 'Spatial dataset generated from the original cartography provided by the competent national agency.'
       topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment'
+      theme: 'http://inspire.ec.europa.eu/theme/tn'
       theme_es: 'http://datos.gob.es/kos/sector-publico/sector/transporte'
       theme_eu: http://publications.europa.eu/resource/authority/data-theme/ENVI
       spatial: '{"coordinates": [[[-32.17,26.79],[44.49,26.79],[44.49,71.30],[-32.17,71.30],[-32.17,26.79]]], "type": "Polygon"}'
       spatial_uri: 'http://datos.gob.es/es/recurso/sector-publico/territorio/Pais/España'
       language:  http://publications.europa.eu/resource/authority/language/SPA
+      provenance: 'The spatial data has been produced as part of the Example project.'
     default_keywords: 
       - name: "test"
         uri: "https://www.example.eu/catalog/organization/test"
       - name: "environment"
         uri: "http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment"
     default_inspire_info:
-      inspireid_theme: 'HB'
+      inspireid_theme: 'TN'
       inspireid_nutscode: 'ES' 
       inspireid_versionid: '2023'
     constraints: 
@@ -93,7 +98,7 @@ harvest_servers:
   - url: '/app/data/sample/xml'
     name: 'XML Folder'
     groups: []
-    active: False
+    active: True
     ckan_name_not_uuid: False
     type: 'xml'
     organization: 'test'
@@ -101,30 +106,34 @@ harvest_servers:
     custom_organization_mapping_file: ''
     private_datasets: True
     default_dcat_info:
-      publisher_name: 'Example Organization'
+      publisher_name: 'Example project'
       publisher_email: 'info@example.eu'
       publisher_identifier: 'https://www.example.eu/org/E05068001'
       publisher_url: 'https://www.example.eu'
       publisher_type: 'http://purl.org/adms/publishertype/NationalAuthority'
       # Default URIs of metadata contact point and resource maintainer
-      maintainer_uri: 'https://www.example.eu/org/E05068001'
-      contact_name: 'Example Organization'
-      contact_email: 'info@example.eu'
-      contact_uri: 'https://www.example.eu/org/E05068001'
-      contact_url: 'https://www.example.eu'
+      maintainer_uri: 'https://example.eu/'
+      contact_uri: 'https://example.eu/'
+      contact_name: 'Example'
+      contact_email: 'info@example.es'
+      contact_url: 'https://example.eu/'
+      topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/farming'
+      lineage_process_steps: 'Spatial dataset generated from the original cartography provided by the competent national agency.'
       topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment'
+      theme: 'http://inspire.ec.europa.eu/theme/tn'
       theme_es: 'http://datos.gob.es/kos/sector-publico/sector/transporte'
       theme_eu: http://publications.europa.eu/resource/authority/data-theme/ENVI
       spatial: '{"coordinates": [[[-32.17,26.79],[44.49,26.79],[44.49,71.30],[-32.17,71.30],[-32.17,26.79]]], "type": "Polygon"}'
       spatial_uri: 'http://datos.gob.es/es/recurso/sector-publico/territorio/Pais/España'
       language:  http://publications.europa.eu/resource/authority/language/SPA
+      provenance: 'The spatial data has been produced as part of the Example project.'
     default_keywords: 
       - name: "test"
         uri: "https://www.example.eu/catalog/organization/test"
       - name: "environment"
         uri: "http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment"
     default_inspire_info:
-      inspireid_theme: 'HB'
+      inspireid_theme: 'TN'
       inspireid_nutscode: 'ES' 
       inspireid_versionid: '2023'
     constraints: 
@@ -132,37 +141,41 @@ harvest_servers:
       mails: []
 
   # XLSX Metadata Example
-  - url: '/app/data/sample/table-sample.xlsx'
+  - url: '/app/data/ckan_geodcat-ap_template-nonspatial_hermes.xlsx'
     name: 'MITMA XLSX'
     groups: []
     active: False
     ckan_name_not_uuid: False
     type: 'table'
-    organization: 'test'
+    organization: 'mitma'
     custom_organization_active: False
     custom_organization_mapping_file: ''
     private_datasets: False
     default_dcat_info:
-      publisher_name: 'Example Organization'
+      publisher_name: 'Example project'
       publisher_email: 'info@example.eu'
       publisher_identifier: 'https://www.example.eu/org/E05068001'
       publisher_url: 'https://www.example.eu'
       publisher_type: 'http://purl.org/adms/publishertype/NationalAuthority'
       # Default URIs of metadata contact point and resource maintainer
-      maintainer_uri: 'https://www.example.eu/org/E05068001'
-      contact_name: 'Example Organization'
-      contact_email: 'info@example.eu'
-      contact_uri: 'https://www.example.eu/org/E05068001'
-      contact_url: 'https://www.example.eu'
+      maintainer_uri: 'https://example.eu/'
+      contact_uri: 'https://example.eu/'
+      contact_name: 'Example'
+      contact_email: 'info@example.es'
+      contact_url: 'https://example.eu/'
+      topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/farming'
+      lineage_process_steps: 'Spatial dataset generated from the original cartography provided by the competent national agency.'
       topic: 'http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/environment'
+      theme: 'http://inspire.ec.europa.eu/theme/tn'
       theme_es: 'http://datos.gob.es/kos/sector-publico/sector/transporte'
       theme_eu: http://publications.europa.eu/resource/authority/data-theme/ENVI
       spatial: '{"coordinates": [[[-32.17,26.79],[44.49,26.79],[44.49,71.30],[-32.17,71.30],[-32.17,26.79]]], "type": "Polygon"}'
-      spatial_uri: 'https://datos.gob.es/es/recurso/sector-publico/territorio/Pais/España'
-      language: 'http://publications.europa.eu/resource/authority/language/SPA'
+      spatial_uri: 'http://datos.gob.es/es/recurso/sector-publico/territorio/Pais/España'
+      language:  http://publications.europa.eu/resource/authority/language/SPA
+      provenance: 'The spatial data has been produced as part of the Example project.'
     default_keywords: 
-      - name: "test"
-        uri: "https://www.example.eu/catalog/organization/test"
+      - name: "mitma"
+        uri: "https://hermes.tragsatec.es/catalogo/organization/mitma"
       - name: "transportation"
         uri: "http://inspire.ec.europa.eu/metadata-codelist/TopicCategory/transportation"
     default_inspire_info:

--- a/ckan-ogc/conf/config.yaml.template
+++ b/ckan-ogc/conf/config.yaml.template
@@ -136,6 +136,7 @@ harvest_servers:
     name: 'MITMA XLSX'
     groups: []
     active: False
+    ckan_name_not_uuid: False
     type: 'table'
     organization: 'test'
     custom_organization_active: False

--- a/ogc2ckan/ckan_datasets/base.py
+++ b/ogc2ckan/ckan_datasets/base.py
@@ -50,7 +50,7 @@ class Distribution:
     def set_rights(self, rights):
         self.rights = rights
 
-    def set_description(self, description):
+    def set_notes(self, description):
         self.description = description
 
     def set_language(self, language):
@@ -111,7 +111,9 @@ class Dataset:
         self.license_id = license_id
         self.identifier = None
         self.title = None
+        self.title_translated = None
         self.notes = None
+        self.notes_translated = None
         self.version_notes = None
         self.language = None
         self.keywords = []
@@ -164,8 +166,14 @@ class Dataset:
     def set_title(self, title):
         self.title = title
 
-    def set_description(self, notes):
+    def set_title_translated(self, title_translated):
+        self.title_translated = title_translated
+
+    def set_notes(self, notes):
         self.notes = notes
+
+    def set_notes_translated(self, notes_translated):
+        self.notes_translated = notes_translated
 
     def set_resource_type(self, resource_type):
         self.dcat_type = resource_type
@@ -402,8 +410,108 @@ class Dataset:
 
         return dataset_dict
 
-    def generate_data(self):
-        dataset_dict = self.dataset_dict()
+    def dataset_dict(self):
+        '''    
+        CKAN API 'package_create': https://docs.ckan.org/en/2.9/api/index.html#ckan.logic.action.create.package_create
+            package_create(
+                name = NULL,
+                title = NULL,
+                private = FALSE,
+                author = NULL,
+                author_email = NULL,
+                maintainer = NULL,
+                maintainer_email = NULL,
+                license_id = NULL,
+                notes = NULL,
+                package_url = NULL,
+                version = NULL,
+                state = "active",
+                type = NULL,
+                resources = NULL,
+                tags = NULL,
+                extras = NULL,
+                relationships_as_object = NULL,
+                relationships_as_subject = NULL,
+                groups = NULL,
+                owner_org = NULL,
+                url = get_default_url(),
+                key = get_default_key(),
+                as = "list",
+                ...
+                )
+        '''
+
+        # Put the details of the dataset we're going to create into a dict.
+        dataset_dict = {
+            'id': self.ckan_id,
+            'name': self.name,
+            'owner_org': self.owner_org,
+            'private': self.private,
+            'groups': self.groups,
+            'title_translated': self.title_translated,
+            'notes_translated': self.notes_translated,
+            'license_id': self.license_id,
+            'topic': self.topic,
+            'tags': self.keywords,
+            'tag_uri': self.keywords_uri,
+            'dcat_type': self.dcat_type,
+            'representation_type': self.representation_type,
+            'access_rights': self.access_rights,
+            'inspire_id': self.inspire_id,
+            'version_notes': self.version_notes,
+            'spatial_resolution_in_meters': self.spatial_resolution_in_meters,
+            'language': self.language,
+            'theme_eu': self.theme_eu,
+            'theme': self.theme,
+            'identifier': self.identifier,
+            'provenance': self.provenance,
+            'lineage_source': self.lineage_source,
+            'lineage_process_steps': self.lineage_process_steps,
+            'source': self.source,
+            'frequency': self.frequency,
+            'reference': self.reference,
+            'conforms_to': self.conformance,
+            'metadata_profile': self.metadata_profile,
+            'encoding': self.encoding,
+            'reference_system': self.reference_system,
+            'spatial': self.spatial,
+            'spatial_uri': self.spatial_uri,
+            'publisher_uri': self.publisher_uri,
+            'publisher_name': self.publisher_name,
+            'publisher_url': self.publisher_url,
+            'publisher_email': self.publisher_email,
+            'publisher_identifier': self.publisher_identifier,
+            'publisher_type': self.publisher_type,
+            'contact_uri': self.contact_uri,
+            'contact_url': self.contact_url,
+            'contact_name': self.contact_name,
+            'contact_email': self.contact_email,
+            'maintainer': self.maintainer_name,
+            'maintainer_uri': self.maintainer_uri,
+            'maintainer_url': self.maintainer_url,
+            'maintainer_email': self.maintainer_email,
+            'author': self.author_name,
+            'author_uri': self.author_uri,
+            'author_email': self.author_email,
+            'author_url': self.author_url,
+            'created': self.created,
+            'modified': self.modified,
+            'temporal_start': self.temporal_start,
+            'temporal_end': self.temporal_end,
+            'valid': self.valid,
+            'extras': [
+            {'key': 'issued', 'value': self.issued},
+        ],
+            'resources': [i.to_dict() for i in self.distributions]
+        }
+
+        return dataset_dict
+
+    def generate_data(self, multilang: bool = False):
+        if multilang is True:
+            dataset_dict = self.dataset_dict_multilang()
+        else:
+            dataset_dict = self.dataset_dict()
         # Use the json module to dump the dictionary to a string for posting.
         quoted_data = urllib.parse.quote(json.dumps(dataset_dict))
         byte_data = quoted_data.encode('utf-8')

--- a/ogc2ckan/ckan_datasets/geodcatap.py
+++ b/ogc2ckan/ckan_datasets/geodcatap.py
@@ -49,7 +49,7 @@ class Distribution:
     def set_rights(self, rights):
         self.rights = rights
 
-    def set_description(self, description):
+    def set_notes(self, description):
         self.description = description
 
     def set_language(self, language):
@@ -113,7 +113,9 @@ class Dataset:
         self.identifier = ckan_id
         self.alternate_identifier = None
         self.title = None
+        self.title_translated = None
         self.notes = None
+        self.notes_translated = None
         self.dcat_type = None
         self.inspire_id = None
         self.access_rights = "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations"
@@ -206,8 +208,14 @@ class Dataset:
     def set_title(self, title):
         self.title = title
 
-    def set_description(self, notes):
+    def set_title_translated(self, title_translated):
+        self.title_translated = title_translated
+
+    def set_notes(self, notes):
         self.notes = notes
+        
+    def set_notes_translated(self, notes_translated):
+        self.notes_translated = notes_translated
 
     def set_resource_type(self, resource_type):
         self.dcat_type = resource_type
@@ -458,8 +466,114 @@ class Dataset:
 
         return dataset_dict
 
-    def generate_data(self):
-        dataset_dict = self.dataset_dict()
+
+    def dataset_dict_multilang(self):
+        '''    
+        CKAN API 'package_create': https://docs.ckan.org/en/2.9/api/index.html#ckan.logic.action.create.package_create
+            package_create(
+                name = NULL,
+                title_translated = NULL,
+                private = FALSE,
+                author = NULL,
+                author_email = NULL,
+                maintainer = NULL,
+                maintainer_email = NULL,
+                license_id = NULL,
+                notes_translated = NULL,
+                package_url = NULL,
+                version = NULL,
+                state = "active",
+                type = NULL,
+                resources = NULL,
+                tags = NULL,
+                extras = NULL,
+                relationships_as_object = NULL,
+                relationships_as_subject = NULL,
+                groups = NULL,
+                owner_org = NULL,
+                url = get_default_url(),
+                key = get_default_key(),
+                as = "list",
+                ...
+                )
+        '''
+
+        # Put the details of the dataset we're going to create into a dict.
+        dataset_dict = {
+            'id': self.ckan_id,
+            'name': self.name,
+            'owner_org': self.owner_org,
+            'private': self.private,
+            'groups': self.groups,
+            'title_translated': self.title_translated,
+            'notes_translated': self.notes_translated,
+            'license_id': self.license_id,
+            'topic': self.topic,
+            'tags': self.keywords,
+            'tag_uri': self.keywords_uri,
+            #TODO: Add tag_thesaurus to CKAN Schema
+            #'tag_thesaurus': self.keywords_thesaurus,
+            'dcat_type': self.dcat_type,
+            'alternate_identifier': self.alternate_identifier,
+            'representation_type': self.representation_type,
+            'access_rights': self.access_rights,
+            'inspire_id': self.inspire_id,
+            'version_notes': self.version_notes,
+            'spatial_resolution_in_meters': self.spatial_resolution_in_meters,
+            'language': self.language,
+            'theme_es': self.theme_es,
+            'theme_eu': self.theme_eu,
+            'theme': self.theme,
+            'identifier': self.identifier,
+            'provenance': self.provenance,
+            'purpose': self.purpose,
+            'lineage_source': self.lineage_source,
+            'lineage_process_steps': self.lineage_process_steps,
+            'source': self.source,
+            'frequency': self.frequency,
+            'reference': self.reference,
+            'conforms_to': self.conformance,
+            'metadata_profile': self.metadata_profile,
+            'encoding': self.encoding,
+            'reference_system': self.reference_system,
+            'spatial': self.spatial,
+            'spatial_uri': self.spatial_uri,
+            'publisher_uri': self.publisher_uri,
+            'publisher_name': self.publisher_name,
+            'publisher_url': self.publisher_url,
+            'publisher_email': self.publisher_email,
+            'publisher_identifier': self.publisher_identifier,
+            'publisher_type': self.publisher_type,
+            'contact_uri': self.contact_uri,
+            'contact_url': self.contact_url,
+            'contact_name': self.contact_name,
+            'contact_email': self.contact_email,
+            'maintainer': self.maintainer_name,
+            'maintainer_uri': self.maintainer_uri,
+            'maintainer_url': self.maintainer_url,
+            'maintainer_email': self.maintainer_email,
+            'author': self.author_name,
+            'author_uri': self.author_uri,
+            'author_email': self.author_email,
+            'author_url': self.author_url,
+            'created': self.created,
+            'modified': self.modified,
+            'temporal_start': self.temporal_start,
+            'temporal_end': self.temporal_end,
+            'valid': self.valid,
+            'extras': [
+            {'key': 'issued', 'value': self.issued},
+        ],
+            'resources': [i.to_dict() for i in self.distributions]
+        }
+
+        return dataset_dict
+
+    def generate_data(self, multilang: bool = False):
+        if multilang is True:
+            dataset_dict = self.dataset_dict_multilang()
+        else:
+            dataset_dict = self.dataset_dict()
         # Use the json module to dump the dictionary to a string for posting.
         quoted_data = urllib.parse.quote(json.dumps(dataset_dict))
         byte_data = quoted_data.encode('utf-8')

--- a/ogc2ckan/config/ckan_config.py
+++ b/ogc2ckan/config/ckan_config.py
@@ -23,6 +23,7 @@ class CKANInfo:
         self.ckan_site_url = os.environ.get('CKAN_URL', OGC2CKAN_CKANINFO_CONFIG['ckan_site_url'])
         self.pycsw_site_url = os.environ.get('PYCSW_URL', OGC2CKAN_CKANINFO_CONFIG['pycsw_site_url'])
         self.authorization_key = os.environ.get('CKAN_API_KEY', OGC2CKAN_CKANINFO_CONFIG['authorization_key'])
+        self.dataset_multilang = True if os.environ.get('CKAN_DATASET_MULTILANG') == 'True' else OGC2CKAN_CKANINFO_CONFIG['dataset_multilang']
         self.default_license = os.environ.get('DEFAULT_LICENSE', OGC2CKAN_CKANINFO_CONFIG['default_license'])
         self.default_license_id = os.environ.get('DEFAULT_LICENSE_ID', OGC2CKAN_CKANINFO_CONFIG['default_license_id'])
         self.ckan_harvester = OGC2CKAN_HARVESTER_CONFIG

--- a/ogc2ckan/controller/ckan_management.py
+++ b/ogc2ckan/controller/ckan_management.py
@@ -78,7 +78,7 @@ def make_request(url: str, ssl_unverified_mode: bool, data: bytes = None, author
     else:
         return None
 
-def create_ckan_datasets(ckan_site_url: str, authorization_key: str, datasets: object, ssl_unverified_mode: bool = False, workspaces: Optional[str] = None) -> Tuple[int, int]:
+def create_ckan_datasets(ckan_site_url: str, authorization_key: str, datasets: object, dataset_multilang: bool, ssl_unverified_mode: bool = False, workspaces: Optional[str] = None) -> Tuple[int, int]:
     """
     Create new datasets on a CKAN server.
 
@@ -86,6 +86,7 @@ def create_ckan_datasets(ckan_site_url: str, authorization_key: str, datasets: o
         ckan_site_url (str): The URL of the CKAN server.
         authorization_key (str): The API key for the CKAN server.
         datasets (object): The datasets to create.
+        dataset_multilang (bool): Whether the dataset is multilingual or not.
         ssl_unverified_mode (bool, optional): Whether to use SSL verification or not. Defaults to False.
         workspaces (str, optional): Only those identifiers starting with identifier_filter (e.g. 'open_data:...') are created. Defaults to None.
 
@@ -93,16 +94,16 @@ def create_ckan_datasets(ckan_site_url: str, authorization_key: str, datasets: o
         Tuple[int, int]: A tuple containing the number of Harvester server records and CKAN new records counters.
     """
     ckan_dataset_errors = []
-    source_dataset_count = len(datasets)
+    ckan_dataset_count = 0
 
     # Check if the datasets already exists in CKAN.
-    datasets, ckan_dataset_errors, ckan_dataset_count = check_ckan_datasets_exists(ckan_site_url, authorization_key, datasets, ssl_unverified_mode, ckan_dataset_errors)
+    datasets, ckan_dataset_errors, source_dataset_count = check_ckan_datasets_exists(ckan_site_url, authorization_key, datasets, ssl_unverified_mode, ckan_dataset_errors)
 
     for dataset in datasets:
         try:
             if workspaces is not None and not any(x.lower() in dataset.ogc_workspace.lower() for x in workspaces):
                 break
-            data = dataset.generate_data()
+            data = dataset.generate_data(dataset_multilang)
             if data is not None:
                 create_ckan_dataset(ckan_site_url, ssl_unverified_mode, data, authorization_key)
                 ckan_dataset_count += 1

--- a/ogc2ckan/harvesters/csw.py
+++ b/ogc2ckan/harvesters/csw.py
@@ -36,7 +36,7 @@ class ObjectFromListDicts:
 
 class HarvesterCSW(Harvester):
     def __init__(self, app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, ckan_name_not_uuid, constraints, **default_dcat_info):
-        super().__init__(app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, **default_dcat_info)
+        super().__init__(app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, ckan_name_not_uuid, **default_dcat_info)
         self.constraints = constraints
         self.csw = None
         self.csw_url = None
@@ -216,7 +216,7 @@ class HarvesterCSW(Harvester):
 
         # Description
         description = custom_metadata.get('description') if custom_metadata else layer_info.identification.abstract
-        dataset.set_description(description or self.localized_strings_dict['description'])
+        dataset.set_notes(description or self.localized_strings_dict['description'])
 
         # CKAN Groups defined in config.yaml
         dataset.set_groups(ckan_groups)
@@ -387,7 +387,11 @@ class HarvesterCSW(Harvester):
 
         # Set keywords from CSW
         self.ows_get_keywords(dataset, layer_info.identification.keywords)
-                
+
+        # Set translated fields if multilang is True
+        if ckan_info.dataset_multilang:
+            self.set_translated_fields(dataset, layer_info, language)
+
         return dataset
 
     def get_distribution(self, ckan_info: CKANInfo, dataset, distribution, record: str, service_type: str, layer_info):

--- a/ogc2ckan/harvesters/ogc.py
+++ b/ogc2ckan/harvesters/ogc.py
@@ -152,7 +152,7 @@ class HarvesterOGC(Harvester):
 
         # Description
         description = custom_metadata.get('description') if custom_metadata else layer_info.abstract
-        dataset.set_description(description or self.localized_strings_dict['description'])
+        dataset.set_notes(description or self.localized_strings_dict['description'])
   
         # CKAN Groups defined in config.yaml
         dataset.set_groups(ckan_groups)
@@ -276,6 +276,10 @@ class HarvesterOGC(Harvester):
         
         # Set keywords/themes/topic categories
         self.set_default_keywords_themes_topic(dataset, custom_metadata, ckan_info.ckan_dataset_schema)
+        
+        # Set translated fields if multilang is True
+        if ckan_info.dataset_multilang:
+            self.set_translated_fields(dataset, layer_info, language)
         
         return dataset
     

--- a/ogc2ckan/harvesters/xml.py
+++ b/ogc2ckan/harvesters/xml.py
@@ -26,7 +26,7 @@ class XmlError(Exception):
 
 class HarvesterXML(Harvester):
     def __init__(self, app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, ckan_name_not_uuid, constraints, **default_dcat_info):
-        super().__init__(self, app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, ckan_name_not_uuid, **default_dcat_info)
+        super().__init__(app_dir, url, name, groups, active, organization, type, custom_organization_active, custom_organization_mapping_file, private_datasets, default_keywords, default_inspire_info, ckan_name_not_uuid, **default_dcat_info)
         self.md_records = None
         self.folder_path = None
         self.formats = OGC2CKAN_HARVESTER_CONFIG['xml']['formats']
@@ -129,7 +129,7 @@ class HarvesterXML(Harvester):
 
         # Description
         description = custom_metadata.get('description') if custom_metadata else layer_info.identification.abstract
-        dataset.set_description(description or self.localized_strings_dict['description'])
+        dataset.set_notes(description or self.localized_strings_dict['description'])
 
         # CKAN Groups defined in config.yaml
         dataset.set_groups(ckan_groups)
@@ -300,6 +300,10 @@ class HarvesterXML(Harvester):
 
         # Set keywords from CSW
         self.ows_get_keywords(dataset, layer_info.identification.keywords)
+
+        # Set translated fields if multilang is True
+        if ckan_info.dataset_multilang:
+            self.set_translated_fields(dataset, layer_info, language)
 
         return dataset
 

--- a/ogc2ckan/mappings/default_ogc2ckan_config.py
+++ b/ogc2ckan/mappings/default_ogc2ckan_config.py
@@ -1,11 +1,12 @@
 # Default values of ogc2ckan
-## File paths
+# File paths
 OGC2CKAN_PATHS_CONFIG = {
     'default_localized_strings_file': 'default_localized_strings.yaml',
+    'default_languages_yaml': 'languages.yaml',
     'default_mappings_folder': 'ogc2ckan/mappings'
 }
 
-## Harvesters develop for this project. ogc2ckan/harvesters/harvesters.py
+# Harvesters develop for this project. ogc2ckan/harvesters/harvesters.py
 OGC2CKAN_HARVESTER_CONFIG = {
     'csw_server': {
         'type': 'csw',
@@ -33,7 +34,7 @@ OGC2CKAN_HARVESTER_CONFIG = {
     },
 }
 
-## CKAN Api routes
+# CKAN Api routes
 OGC2CKAN_CKAN_API_ROUTES = {
     'create_ckan_dataset': '/api/3/action/package_create',
     'update_ckan_dataset': '/api/3/action/package_update',
@@ -46,11 +47,12 @@ OGC2CKAN_CKAN_API_ROUTES = {
     'get_ckan_dataset_info': '/api/3/action/package_search?q={field}:"{field_value}"',
 }
 
-## CKANInfo class default configuration
+# CKANInfo class default configuration
 OGC2CKAN_CKANINFO_CONFIG = {
     'ckan_site_url': 'http://localhost:5000',
     'pycsw_site_url': 'http://localhost:8000',
     'authorization_key': None,
+    'dataset_multilang': False,
     'default_license': 'http://creativecommons.org/licenses/by/4.0/',
     'default_license_id': 'cc-by',
     'parallelization': False,
@@ -61,7 +63,7 @@ OGC2CKAN_CKANINFO_CONFIG = {
     'ckan_fields_json': 'geodcatap.json'
 }
 
-## DBDsn class default configuration
+# DBDsn class default configuration
 OGC2CKAN_DBDSN_CONFIG = {
     'host': 'localhost',
     'port': '5432',
@@ -70,7 +72,16 @@ OGC2CKAN_DBDSN_CONFIG = {
     'password': 'password'
 }
 
-## Default DCAT metadata configuration
+# Metadata multilang fields avalaibles, schema: geodcatap_es
+OGC2CKAN_MD_MULTILANG_FIELDS = {
+    'title': 'title_translated',
+    'notes': 'notes_translated',
+    'provenance': 'provenance',
+    'purpose': 'purpose',
+    'version_notes': 'version_notes'
+}
+
+# Default DCAT metadata configuration
 OGC2CKAN_HARVESTER_MD_CONFIG = {
     'access_rights': 'http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations',
     'conformance': [
@@ -172,3 +183,6 @@ OGC2CKAN_ISO_MD_ELEMENTS = {
     'lineage_process_steps': 'gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:processStep'
     
 }
+
+# loose definition of BCP47-like strings
+BCP_47_LANGUAGE = u'^[a-z]{2,8}(-[0-9a-zA-Z]{1,8})*$'

--- a/ogc2ckan/mappings/language.yaml
+++ b/ogc2ckan/mappings/language.yaml
@@ -1,0 +1,92 @@
+-
+   id: http://publications.europa.eu/resource/authority/language/ENG
+   iso_639_2: en
+   iso_639_3: eng
+-
+   id: http://publications.europa.eu/resource/authority/language/SPA
+   iso_639_2: es
+   iso_639_3: spa
+-
+   id: http://publications.europa.eu/resource/authority/language/DEU
+   iso_639_2: de
+   iso_639_3: deu
+-
+   id: http://publications.europa.eu/resource/authority/language/FRA
+   iso_639_2: fr
+   iso_639_3: fra
+-
+   id: http://publications.europa.eu/resource/authority/language/ITA
+   iso_639_2: it
+   iso_639_3: ita
+-
+   id: http://publications.europa.eu/resource/authority/language/POR
+   iso_639_2: pt
+   iso_639_3: por
+-
+   id: http://publications.europa.eu/resource/authority/language/NLD
+   iso_639_2: nl
+   iso_639_3: nld
+-
+   id: http://publications.europa.eu/resource/authority/language/SWE
+   iso_639_2: sv
+   iso_639_3: swe
+-
+   id: http://publications.europa.eu/resource/authority/language/POL
+   iso_639_2: pl
+   iso_639_3: pol
+-
+   id: http://publications.europa.eu/resource/authority/language/DAN
+   iso_639_2: da
+   iso_639_3: dan
+-
+   id: http://publications.europa.eu/resource/authority/language/FIN
+   iso_639_2: fi
+   iso_639_3: fin
+-
+   id: http://publications.europa.eu/resource/authority/language/EST
+   iso_639_2: et
+   iso_639_3: est
+-
+   id: http://publications.europa.eu/resource/authority/language/LVA
+   iso_639_2: lv
+   iso_639_3: lav
+-
+   id: http://publications.europa.eu/resource/authority/language/LTU
+   iso_639_2: lt
+   iso_639_3: lit
+-
+   id: http://publications.europa.eu/resource/authority/language/CZE
+   iso_639_2: cs
+   iso_639_3: ces
+-
+   id: http://publications.europa.eu/resource/authority/language/SLO
+   iso_639_2: sk
+   iso_639_3: slk
+-
+   id: http://publications.europa.eu/resource/authority/language/HUN
+   iso_639_2: hu
+   iso_639_3: hun
+-
+   id: http://publications.europa.eu/resource/authority/language/SLV
+   iso_639_2: sl
+   iso_639_3: slv
+-
+   id: http://publications.europa.eu/resource/authority/language/BUL
+   iso_639_2: bg
+   iso_639_3: bul
+-
+   id: http://publications.europa.eu/resource/authority/language/ROM
+   iso_639_2: ro
+   iso_639_3: ron
+-
+   id: http://publications.europa.eu/resource/authority/language/HRV
+   iso_639_2: hr
+   iso_639_3: hrv
+-
+   id: http://publications.europa.eu/resource/authority/language/MAL
+   iso_639_2: mt
+   iso_639_3: mlt
+-
+   id: http://publications.europa.eu/resource/authority/language/GRE
+   iso_639_2: el
+   iso_639_3: ell

--- a/ogc2ckan/model/harvest_schema.py
+++ b/ogc2ckan/model/harvest_schema.py
@@ -48,13 +48,14 @@ class HarvesterSchema:
                     "contact_uri": {"type": "string"},
                     "contact_url": {"type": "string"},
                     "topic": {"type": "string"},
+                    "theme": {"type": "string"},                    
                     "theme_es": {"type": "string"},
                     "theme_eu": {"type": "string"},
                     "spatial": {"type": "string"},
                     "spatial_uri": {"type": "string"},
                     "language": {"type": "string"},
                 },
-                "required": ["publisher_name", "publisher_email", "publisher_identifier", "publisher_url", "publisher_type", "contact_name", "contact_email", "contact_uri", "contact_url", "topic", "theme_eu", "spatial", "spatial_uri", "language"]
+                "required": ["publisher_name", "publisher_email", "publisher_identifier", "publisher_url", "publisher_type", "contact_name", "contact_email", "contact_uri", "contact_url", "topic", "theme", "theme_eu", "spatial", "spatial_uri", "language"]
             },
             "default_keywords": {
                 "type": "array",

--- a/ogc2ckan/ogc2ckan.py
+++ b/ogc2ckan/ogc2ckan.py
@@ -53,14 +53,14 @@ def launch_harvest(harvest_server=None, ckan_info=None):
         diff = end - start
 
         # Log CKAN Datasets with conflicts
-        logging.info(log_module + ":" + harvest_server["name"] + " (" + harvester.type.upper() + ") dataset records retrieved (" + str(harvester.source_dataset_count) + ") with conflicts: (" + str(harvester.source_dataset_count - harvester.ckan_dataset_count) + ") from ('" + harvester.type.upper() + "')")
+        logging.info(log_module + ":" + harvest_server["name"] + " (" + harvester.type.upper() + ") dataset records retrieved (" + str(harvester.source_dataset_count) + ") with conflicts: (" + str(len(harvester.ckan_dataset_errors)) + ") from ('" + harvester.type.upper() + "')")
         
         if harvester.ckan_dataset_errors:
             logging.info(log_module + ":" + "Check Datasets with conflicts by 'title': " + json.dumps(harvester.ckan_dataset_errors, ensure_ascii=False))
         
         # Log CKAN Data Dictionaries with conflicts
         if harvester.source_dictionaries_count > 0 or harvester.ckan_dictionaries_count > 0:
-            logging.info(log_module + ":" + harvest_server["name"] + " (" + harvester.type.upper() + ") data dictionaries retrieved (" + str(harvester.source_dictionaries_count) + ") with conflicts: (" + str(harvester.source_dictionaries_count - harvester.ckan_dictionaries_count) + ") from ('" + harvester.type.upper() + "')")
+            logging.info(log_module + ":" + harvest_server["name"] + " (" + harvester.type.upper() + ") data dictionaries retrieved (" + str(harvester.source_dictionaries_count) + ") with conflicts: (" + str(len(harvester.ckan_dictionaries_errors)) + ") from ('" + harvester.type.upper() + "')")
             
             if harvester.ckan_dictionaries_errors:
                 logging.info(log_module + ":" + "Check Data dictionaries with conflicts by 'resource_id': " + json.dumps(harvester.ckan_dictionaries_errors, ensure_ascii=False))
@@ -155,7 +155,7 @@ def main():
         logging.error(f"{log_module}: Error reading configuration file: {e}")
              
 if __name__ == "__main__":
-    if DEV_MODE == True or DEV_MODE == "True":
+    if DEV_MODE == True or DEV_MODE.lower() == "true":
         # Allow other computers to attach to ptvsd at this IP address and port.
         ptvsd.enable_attach(address=("0.0.0.0", CKAN_OGC_DEV_PORT), redirect_output=True)
 


### PR DESCRIPTION
Add multilang to env https://github.com/mjanez/ckan-ogc/commit/7cf175af0b2f5ecf27da0086ae7ea74f8dd870b7 https://github.com/mjanez/ckan-ogc/issues/20

- Add ENV to Dockerfiles.
- Add core multilang fields to ckan_dataset schemas ('_translated)
- Add dataset.multilang to CKAN Config.
- Add generate_data function to multilang fields.
- Add language mappings (authority tables, ISO_639_2 and ISO_639_3).
- Fix dataset count logging.